### PR TITLE
ci: publish for pkg.pr.new when create PR

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,22 @@
+name: Publish to pkg.pr.new
+
+on:
+  push: null
+  pull_request: null
+
+jobs:
+  pkg-pr-new:
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - run: npm run build
+      - run: npx pkg-pr-new publish


### PR DESCRIPTION
### Is your suggesting new feature related to a problem?

It is troublesome to build at hand to check the contents of the PR.

### Describe the solution you'd like

Publishing to pkg.pr.new make it easier to test it when we create a PR.

You can choose Pull Request template.  (Select `Preview` tab first)

### Additional context

<https://github.com/stackblitz-labs/pkg.pr.new>

Note: We need install <https://github.com/apps/pkg-pr-new> to make this feature work well.